### PR TITLE
Fix responsiveness and scrolling

### DIFF
--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -5,9 +5,6 @@
     .currentFeatures, .splash {
         flex-direction: column !important;
     }
-    .transition {
-        margin-bottom: -3.5em !important;
-    }
     .lt-flex-66 {
         flex: none;
     }
@@ -32,12 +29,6 @@
     .introHeader {
         margin-top: 1em !important;
     }
-    .features {
-        margin-top: 3em !important;
-    }
-    .featureDiv {
-        margin: 1em 0em !important;
-    }
     .socialMedia {
         flex-direction: row !important;
     }
@@ -52,5 +43,19 @@
     }
     .testimonial_decal {
         display: none;
+    }
+}
+@media all and (max-width: 720px) {
+    .transition {
+        margin-bottom: -3.5em !important;
+    }
+    .currentFeatures {
+        flex-direction: column !important;
+    }
+    .features {
+        margin-top: 3em !important;
+    }
+    .featureDiv {
+        margin: 1em 0em !important;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -167,6 +167,9 @@ a {
     color: var(--darkblue);
     cursor: pointer;
 }
+.main {
+    overflow: hidden;
+}
 
 .splash {
     align-items: center;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -121,6 +121,7 @@
 </div>
 
 <!--Testimonial animation-->
+<script defer src="https://unpkg.com/smoothscroll-polyfill@0.4.4/dist/smoothscroll.min.js"></script>
 <script>
     // smooth scrolling link
     const scrollTo = element => {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="lt-content-column">
+<div class="main lt-content-column">
     <!-- Splash Page -->
     <div class="splash lt-flex-row">
         <div class="splashText lt-flex-50">


### PR DESCRIPTION
Fixes the three-column layout by adding another breakpoint at `720px`, smooth-scrolling on Safari, and prevents overflowing in the splash section
Closes #50 